### PR TITLE
Decouple the id check from the cloud function

### DIFF
--- a/functions/yt-url-consumer/main.py
+++ b/functions/yt-url-consumer/main.py
@@ -182,7 +182,6 @@ def transcript_downloader(cloud_event: functions_framework.CloudEvent) -> None:
         return 400
 
     info = YDL.extract_info(URL, download=False)
-    print(info)
     insert_transcript(info)
 
     print(f"Elapsed Time: {time.time() - startTime}")

--- a/transcript_api/requirements.txt
+++ b/transcript_api/requirements.txt
@@ -1,4 +1,3 @@
-firebase-admin==6.0.1
 functions-framework==3.5.0
 google-api-core==2.17.1
 google-api-python-client==2.119.0


### PR DESCRIPTION
Remove the id check and the publishing from the cloud function, moving it to another cloud function so that it happen asynchronously. This makes it so transcript-api is able to run faster and uses less memory overall.